### PR TITLE
Add GitHub Action to automate updates to Data Set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,11 @@ APP_URL=http://localhost
 
 LOG_CHANNEL=stack
 
-DB_CONNECTION=mysql
+DB_CONNECTION=sqlite
 DB_HOST=127.0.0.1
 DB_PORT=3306
-DB_DATABASE=homestead
-DB_USERNAME=homestead
+DB_DATABASE=./database/database.sqlite
+DB_USERNAME=
 DB_PASSWORD=secret
 
 BROADCAST_DRIVER=log

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,28 @@
+workflow "New Monthly Build" {
+  on = "schedule(15 1 1 * *)"
+  resolves = [
+    "auto-commit-monthly-build"
+  ]
+}
+
+# Install composer dependencies
+action "composer install" {
+  uses = "MilesChou/composer-action@master"
+  args = "install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist"
+}
+
+action "update-data" {
+  needs = ["composer install"]
+  uses = "./actions/update-data/"
+}
+
+action "auto-commit-monthly-build" {
+  needs = ["update-data"]
+  uses = "stefanzweifel/git-auto-commit-action@v1.0.0"
+  secrets = ["GITHUB_TOKEN"]
+  env = {
+    COMMIT_MESSAGE = "Update Data Set"
+    COMMIT_AUTHOR_EMAIL  = "hello@stefanzweifel.io"
+    COMMIT_AUTHOR_NAME = "Stefan Zweifel"
+  }
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,7 +8,7 @@ workflow "New Monthly Build" {
 # Install composer dependencies
 action "composer install" {
   uses = "MilesChou/composer-action@master"
-  args = "install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist"
+  args = "install --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist"
 }
 
 action "update-data" {

--- a/actions/update-data/Dockerfile
+++ b/actions/update-data/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:7.3-cli-alpine
+
+LABEL "com.github.actions.name"="Update Dataset"
+LABEL "com.github.actions.description"="Fetch download numbers and create new HTML Build"
+LABEL "com.github.actions.icon"="check-circle"
+LABEL "com.github.actions.color"="green"
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/update-data/entrypoint.sh
+++ b/actions/update-data/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+set -eu
+
+#  Setup Laravel App
+cp .env.example .env
+php artisan key:generate
+
+# Fetch download numbers for last month
+php artisan app:fetch-downloads
+
+# Create new HTML Export
+php artisan export


### PR DESCRIPTION
Adds Workflow and GitHub Actions to automate the entire process of updating the site.

- At the first day of the month fetch download numbers
- Create a "export"
- Commit changed files and push them back to GitHub